### PR TITLE
WIP: Update for 7.0.0 (fixes #1)

### DIFF
--- a/nuspec/Piranha.AspNetCore.Identity.PostgreSQL.nuspec
+++ b/nuspec/Piranha.AspNetCore.Identity.PostgreSQL.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Piranha.AspNetCore.Identity.PostgreSQL</id>
     <title>Piranha AspNetCore Identity PostgreSQL</title>
-    <version>6.1.0</version>
+    <version>7.0.0</version>
     <authors>Jason Underhill</authors>
     <owners>Jason Underhill</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/nuspec/Piranha.AspNetCore.Identity.PostgreSQL.nuspec
+++ b/nuspec/Piranha.AspNetCore.Identity.PostgreSQL.nuspec
@@ -15,10 +15,9 @@
     <iconUrl>http://piranhacms.org/assets/twitter-shield.png</iconUrl>
     <dependencies>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="Piranha" version="[6.1.0,7.0.0)" />
-        <dependency id="Piranha.AspNetCore.Identity" version="[6.1.0,7.0.0)" />
-        <dependency id="Microsoft.AspNetCore.Identity.EntityFrameworkCore" version="2.1.3" />
-        <dependency id="Npgsql.EntityFrameworkCore.PostgreSQL" version="2.1.2" />
+        <dependency id="Piranha.AspNetCore.Identity" version="[7.0.0,8.0.0)" />
+        <dependency id="Microsoft.AspNetCore.Identity.EntityFrameworkCore" version="2.2.0" />
+        <dependency id="Npgsql.EntityFrameworkCore.PostgreSQL" version="2.2.4" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Piranha.AspNetCore.Identity.PostgreSQL/Piranha.AspNetCore.Identity.PostgreSQL.csproj
+++ b/src/Piranha.AspNetCore.Identity.PostgreSQL/Piranha.AspNetCore.Identity.PostgreSQL.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>6.1.0</Version>
+    <Version>7.0.0</Version>
     <Company>Piranha CMS</Company>
     <AssemblyTitle>Piranha.AspNetCore.Identity.PostgreSQL</AssemblyTitle>
     <RootNamespace>Piranha.AspNetCore.Identity.PostgreSQL</RootNamespace>

--- a/src/Piranha.AspNetCore.Identity.PostgreSQL/Piranha.AspNetCore.Identity.PostgreSQL.csproj
+++ b/src/Piranha.AspNetCore.Identity.PostgreSQL/Piranha.AspNetCore.Identity.PostgreSQL.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.1.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.1.4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.2" />
-    <PackageReference Include="Piranha.AspNetCore.Identity" Version="6.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.2.4" />
+    <PackageReference Include="Piranha.AspNetCore.Identity" Version="7.0.0-rc1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi,

I updated the dependencies/version numbers for 7.0.0. I compared to the two providers in the main Piranha package (SQLServer and SQLite) and they also had no further changes.

`Piranha.AspNetCore.Identity` is still referenced as `7.0.0-rc1`, I can update that as soon as `7.0.0` is out (and mark this as mergeable).

Is there something specific that should be tested? I just ran a project that's being built with 7.0.0 and postgres and checked manually to see if it's working.